### PR TITLE
Simplify QOpenGLPage::active property handling.

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -37,7 +37,7 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
   , d(new QGraphicsMozViewPrivate(new IMozQView<QOpenGLWebPage>(*this), this))
   , mParentID(0)
   , mPrivateMode(false)
-  , mActive(true)
+  , mActive(false)
   , mBackground(false)
   , mLoaded(false)
   , mCompleted(false)
@@ -46,7 +46,6 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
     d->mContext = QMozContext::GetInstance();
     d->mHasContext = true;
 
-    connect(this, SIGNAL(setIsActive(bool)), this, SLOT(SetIsActive(bool)));
     connect(this, SIGNAL(viewInitialized()), this, SLOT(processViewInitialization()));
     connect(this, SIGNAL(loadProgressChanged()), this, SLOT(updateLoaded()));
     connect(this, SIGNAL(loadingChanged()), this, SLOT(updateLoaded()));
@@ -65,18 +64,6 @@ QOpenGLWebPage::~QOpenGLWebPage()
         d->mContext->GetApp()->DestroyView(d->mView);
     }
     delete d;
-}
-
-void QOpenGLWebPage::SetIsActive(bool aIsActive)
-{
-    if (d->mView) {
-        d->mView->SetIsActive(aIsActive);
-        if (aIsActive) {
-            d->mView->ResumeRendering();
-        } else {
-            d->mView->SuspendRendering();
-        }
-    }
 }
 
 void QOpenGLWebPage::updateLoaded()
@@ -242,15 +229,17 @@ bool QOpenGLWebPage::active() const
 
 void QOpenGLWebPage::setActive(bool active)
 {
-    if (d->mViewInitialized) {
-        if (mActive != active) {
-            mActive = active;
-            Q_EMIT activeChanged();
-        }
-        SetIsActive(active);
-    } else {
-        // Will be processed once view is initialized.
+    // WebPage is in inactive state until the view is initialized.
+    // ::processViewInitialization always forces active state so we
+    // can just ignore early activation calls.
+    if (!d->mViewInitialized)
+        return;
+
+    if (mActive != active) {
         mActive = active;
+        d->mView->SetIsActive(mActive);
+        mActive ? d->mView->ResumeRendering() : d->mView->SuspendRendering();
+        Q_EMIT activeChanged();
     }
 }
 

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -96,7 +96,6 @@ public Q_SLOTS:
     void updateContentOrientation(Qt::ScreenOrientation orientation);
 
 Q_SIGNALS:
-    void setIsActive(bool);
     void parentIdChanged();
     void privateModeChanged();
     void completedChanged();
@@ -115,7 +114,6 @@ Q_SIGNALS:
 
 private Q_SLOTS:
     void processViewInitialization();
-    void SetIsActive(bool aIsActive);
     void updateLoaded();
     void createView();
 


### PR DESCRIPTION
1. Remove setIsActive signal. It was probably copied from QQuickMozView.
   Nothing emits it in case of QOpenGLPage so the codepath is dead.
2. Merge setActive and SetIsActive functions. They are pretty simple and
   SetIsActive is only called from setActive anyway. It's easier to
   understand the code without two activation calls.
3. Set QOpenGLPage::mActive default value to false. The code actually
   implies the view remains inactive until it's initialized.
   QOpenGLWebPage::processViewInitialization always calls
   forceActiveFocus which forces active state. This also means we can
   simply ignore setActive calls until view is initialized.

Ref: JB#28807

Signed-off-by: Piotr Tworek <piotr.tworek@jollamobile.com>