### PR TITLE
[qtmozembed] Clear compositing surface on active page destruction. JB…

### DIFF
--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -55,6 +55,9 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
 QOpenGLWebPage::~QOpenGLWebPage()
 {
     if (d->mView) {
+        if (mActive) {
+            d->mView->ClearContent(255, 255, 255, 0);
+        }
         d->mView->SetListener(NULL);
         d->mContext->GetApp()->DestroyView(d->mView);
     }


### PR DESCRIPTION
…#29995

If the currently active QOpenGLWebPage is being destroyed clear it's
compositing surface (shared with all other QOpenGLWebPage instances).
This should ensure we won't see the content of just closed page before
another page draws it's content. An extreme case of such problem can be
seen when the page being closed is the only one being open. In such
case the compositing surface will contain the content of the just
closed page until the user loads a new one.