### PR TITLE
[qtmozembed] Add ability to infor gecko we're not ready to render. Contributes to JB#31866

### DIFF
--- a/src/qgraphicsmozview.cpp
+++ b/src/qgraphicsmozview.cpp
@@ -135,6 +135,11 @@ void QGraphicsMozView::drawOverlay(const QRect &rect) {
     // Do nothing;
 }
 
+bool QGraphicsMozView::preRender()
+{
+    return true;
+}
+
 /*! \reimp
 */
 QSizeF QGraphicsMozView::sizeHint(Qt::SizeHint which, const QSizeF& constraint) const

--- a/src/qgraphicsmozview_p.cpp
+++ b/src/qgraphicsmozview_p.cpp
@@ -111,6 +111,11 @@ void QGraphicsMozViewPrivate::DrawUnderlay()
     mViewIface->drawUnderlay();
 }
 
+bool QGraphicsMozViewPrivate::PreRender()
+{
+    return mViewIface->preRender();
+}
+
 void QGraphicsMozViewPrivate::DrawOverlay(const nsIntRect& aRect)
 {
     QRect rect(aRect.x, aRect.y, aRect.width, aRect.height);

--- a/src/qgraphicsmozview_p.h
+++ b/src/qgraphicsmozview_p.h
@@ -79,6 +79,7 @@ public:
     // Called always from the compositor thread.
     virtual void DrawUnderlay();
     virtual void DrawOverlay(const nsIntRect& aRect);
+    virtual bool PreRender();
 
     void UpdateScrollArea(unsigned int aWidth, unsigned int aHeight, float aPosX, float aPosY);
     void TestFlickingMode(QTouchEvent *event);

--- a/src/qmozview_defined_wrapper.h
+++ b/src/qmozview_defined_wrapper.h
@@ -131,7 +131,8 @@ Q_DECLARE_METATYPE(QMozReturnValue) \
     bool Invalidate(); \
     void requestGLContext(bool& hasContext, QSize& viewPortSize); \
     void drawUnderlay(); \
-    void drawOverlay(const QRect &rect);
+    void drawOverlay(const QRect &rect); \
+    bool preRender();
 
 #define Q_MOZ_VIEW_SIGNALS \
     void viewInitialized(); \

--- a/src/qmozview_templated_wrapper.h
+++ b/src/qmozview_templated_wrapper.h
@@ -24,6 +24,7 @@ public:
     virtual void requestGLContext(bool& hasContext, QSize& viewPortSize) = 0;
     virtual void drawUnderlay() = 0;
     virtual void drawOverlay(const QRect &rect) = 0;
+    virtual bool preRender() = 0;
 
     // Signals
     virtual void viewInitialized() = 0;
@@ -190,6 +191,11 @@ public:
     void drawOverlay(const QRect &rect)
     {
         view.drawOverlay(rect);
+    }
+
+    bool preRender()
+    {
+        return view.preRender();
     }
 
     void useQmlMouse(bool value)

--- a/src/qopenglwebpage.cpp
+++ b/src/qopenglwebpage.cpp
@@ -44,6 +44,7 @@ QOpenGLWebPage::QOpenGLWebPage(QObject *parent)
   , mWindow(0)
   , mSizeUpdateScheduled(false)
   , mThrottlePainting(false)
+  , mReadyToPaint(true)
 {
     d->mContext = QMozContext::GetInstance();
     d->mHasContext = true;
@@ -153,6 +154,12 @@ void QOpenGLWebPage::drawUnderlay()
         funcs->glClearColor(bgColor.redF(), bgColor.greenF(), bgColor.blueF(), 0.0);
         funcs->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     }
+}
+
+bool QOpenGLWebPage::preRender()
+{
+    QMutexLocker lock(&mReadyToPaintMutex);
+    return mReadyToPaint;
 }
 
 /*!
@@ -342,6 +349,22 @@ void QOpenGLWebPage::setThrottlePainting(bool throttle)
     if (mThrottlePainting != throttle) {
         mThrottlePainting = throttle;
         d->SetThrottlePainting(throttle);
+        Q_EMIT throttlePaintingChanged();
+    }
+}
+
+bool QOpenGLWebPage::readyToPaint() const
+{
+    QMutexLocker lock(&mReadyToPaintMutex);
+    return mReadyToPaint;
+}
+
+void QOpenGLWebPage::setReadyToPaint(bool ready)
+{
+    QMutexLocker lock(&mReadyToPaintMutex);
+    if (mReadyToPaint != ready) {
+        mReadyToPaint = ready;
+        Q_EMIT readyToPaintChanged();
     }
 }
 

--- a/src/qopenglwebpage.h
+++ b/src/qopenglwebpage.h
@@ -37,6 +37,7 @@ class QOpenGLWebPage : public QObject
     Q_PROPERTY(bool loaded READ loaded NOTIFY loadedChanged FINAL)
     Q_PROPERTY(QWindow *window READ window WRITE setWindow NOTIFY windowChanged FINAL)
     Q_PROPERTY(bool throttlePainting READ throttlePainting WRITE setThrottlePainting NOTIFY throttlePaintingChanged FINAL)
+    Q_PROPERTY(bool readyToPaint READ readyToPaint WRITE setReadyToPaint NOTIFY readyToPaintChanged FINAL)
 
     Q_MOZ_VIEW_PRORERTIES
 
@@ -75,6 +76,9 @@ public:
     bool throttlePainting() const;
     void setThrottlePainting(bool);
 
+    bool readyToPaint() const;
+    void setReadyToPaint(bool);
+
     void initialize();
 
     virtual bool event(QEvent *event);
@@ -112,6 +116,7 @@ Q_SIGNALS:
     void requestGLContext();
     void afterRendering(const QRect &rect);
     void throttlePaintingChanged();
+    void readyToPaintChanged();
 
     Q_MOZ_VIEW_SIGNALS
 
@@ -138,6 +143,8 @@ private:
     QMutex mGrabResultListLock;
     bool mSizeUpdateScheduled;
     bool mThrottlePainting;
+    mutable QMutex mReadyToPaintMutex;
+    bool mReadyToPaint;
 
     Q_DISABLE_COPY(QOpenGLWebPage)
 };

--- a/src/quickmozview.cpp
+++ b/src/quickmozview.cpp
@@ -141,6 +141,11 @@ void QuickMozView::drawOverlay(const QRect &rect)
     // Do nothing;
 }
 
+bool QuickMozView::preRender()
+{
+    return true;
+}
+
 void QuickMozView::updateGLContextInfo(QOpenGLContext* ctx)
 {
     d->mHasContext = ctx != nullptr && ctx->surface() != nullptr;


### PR DESCRIPTION
Add QOpenGLWebPage::readyToPaint property. This allows us to customize
the value we return from EmbedLiteViewListener::PreRender. When set to
false we're basically telling the compositor it shouldn't paint the
content for the current view. This is similar to the already existing
suspendRendering function, there are some differences however:
1. SuspendRendering makes the compositor loose it's EGLContext and
   EGLSurface handles.
2. The implementation of suspendRendering function is async. This means
   the composition will be paused some time in the future after the
   function is called. Setting QOpenGLWebPage::readyToPaint to false
   will ensure that the already scheduled rendering op will be skipped.
3. The CompositorOGL::Pause which suspendRendering uses is intended to
   stop the compositor from doing any work. As such it makes it ideal in
   situations where we want to stop composition for loner periods of
   time. The mReadyToPaint is based on nsIWidget::PreRender function
   which is much lighter, it only skips next frame. It does not modify the actual
   compositor state. The compositor remains fully functional. It can for example
   keep receiving new video frames from media thread, it just won't try to render them.